### PR TITLE
Initialize migration to 14.0

### DIFF
--- a/odoo_module_migrate/config.py
+++ b/odoo_module_migrate/config.py
@@ -34,6 +34,11 @@ _AVAILABLE_MIGRATION_STEPS = [
         "target_version_name": "13.0",
         "init_version_code": "120",
         "target_version_code": "130",
+    }, {
+        "init_version_name": "13.0",
+        "target_version_name": "14.0",
+        "init_version_code": "130",
+        "target_version_code": "140",
     },
 ]
 

--- a/odoo_module_migrate/migration_scripts/migrate_130_140.py
+++ b/odoo_module_migrate/migration_scripts/migrate_130_140.py
@@ -1,0 +1,12 @@
+# Copyright (C) 2020 - Today: Iván Todorovich
+# @author: Iván Todorovich (https://twitter.com/ivantodorovich)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+_TEXT_ERRORS = {
+    ".xml": {
+        "<act_window(\n|.|\t)*":
+        "act_window tag has been deprecated. Use <record> instead",
+        "<report(\n|.|\t)*":
+        "report tag has been deprecated. Use <record> instead",
+    }
+}


### PR DESCRIPTION
Not much, just initializing `14.0` migration and adding simple error messages for deprecated `act_window` and `report` tags


REL: https://github.com/OCA/odoo-module-migrator/issues/32