### PR TITLE
Update regexp to detect <tree> tag with color attribute

### DIFF
--- a/odoo_module_migrate/migration_scripts/migrate_100_110.py
+++ b/odoo_module_migrate/migration_scripts/migrate_100_110.py
@@ -46,9 +46,11 @@ _TEXT_ERRORS = {
     },
     ".xml": {
         r"<tree[\s][^>]*colors=":
-        "colors attribute is deprecated in tree view. Use decoration- instead.",
+        "colors attribute is deprecated in tree view."
+        " Use decoration- instead.",
         r"<tree[\s][^>]*fonts=":
-        "fonts attribute is deprecated in tree view. Use decoration- instead.",
+        "fonts attribute is deprecated in tree view."
+        " Use decoration- instead.",
     }
 }
 

--- a/odoo_module_migrate/migration_scripts/migrate_100_110.py
+++ b/odoo_module_migrate/migration_scripts/migrate_100_110.py
@@ -46,7 +46,7 @@ _TEXT_ERRORS = {
             "report.external_layout_footer is obsolete.",
     },
     ".xml": {
-        "<tree(\n|.|\t)*color=\"[^>]*":
+        "<tree[ \n\t][^>]*color=":
         "color attribute is deprecated in tree view. Use decoration- instead.",
     }
 }

--- a/odoo_module_migrate/migration_scripts/migrate_100_110.py
+++ b/odoo_module_migrate/migration_scripts/migrate_100_110.py
@@ -46,8 +46,10 @@ _TEXT_ERRORS = {
             "report.external_layout_footer is obsolete.",
     },
     ".xml": {
-        "<tree[ \n\t][^>]*color=":
-        "color attribute is deprecated in tree view. Use decoration- instead.",
+        "<tree[ \n\t][^>]*colors=":
+        "colors attribute is deprecated in tree view. Use decoration- instead.",
+        "<tree[ \n\t][^>]*fonts=":
+        "fonts attribute is deprecated in tree view. Use decoration- instead.",
     }
 }
 

--- a/odoo_module_migrate/migration_scripts/migrate_100_110.py
+++ b/odoo_module_migrate/migration_scripts/migrate_100_110.py
@@ -47,9 +47,11 @@ _TEXT_ERRORS = {
     },
     ".xml": {
         "<tree[ \n\t][^>]*colors=":
-        "colors attribute is deprecated in tree view. Use decoration- instead.",
+        "colors attribute is deprecated in tree view."
+        " Use decoration- instead.",
         "<tree[ \n\t][^>]*fonts=":
-        "fonts attribute is deprecated in tree view. Use decoration- instead.",
+        "fonts attribute is deprecated in tree view."
+        " Use decoration- instead.",
     }
 }
 

--- a/odoo_module_migrate/migration_scripts/migrate_100_110.py
+++ b/odoo_module_migrate/migration_scripts/migrate_100_110.py
@@ -45,9 +45,9 @@ _TEXT_ERRORS = {
             "report.external_layout_footer is obsolete.",
     },
     ".xml": {
-        "<tree[\s][^>]*colors=":
+        r"<tree[\s][^>]*colors=":
         "colors attribute is deprecated in tree view. Use decoration- instead.",
-        "<tree[\s][^>]*fonts=":
+        r"<tree[\s][^>]*fonts=":
         "fonts attribute is deprecated in tree view. Use decoration- instead.",
     }
 }

--- a/odoo_module_migrate/migration_scripts/migrate_100_110.py
+++ b/odoo_module_migrate/migration_scripts/migrate_100_110.py
@@ -46,10 +46,10 @@ _TEXT_ERRORS = {
             "report.external_layout_footer is obsolete.",
     },
     ".xml": {
-        "<tree[ \n\t][^>]*colors=":
+        r"<tree[\s][^>]*colors=":
         "colors attribute is deprecated in tree view."
         " Use decoration- instead.",
-        "<tree[ \n\t][^>]*fonts=":
+        r"<tree[\s][^>]*fonts=":
         "fonts attribute is deprecated in tree view."
         " Use decoration- instead.",
     }


### PR DESCRIPTION
Migrations of some XML-files took minutes, and some seemed to get totally stuck with the old regexp. I think this one should work for most cases, and all files were processed in less than a second.