### PR TITLE
[IMP] MIgrate toggle-active button to v13

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,6 +104,9 @@ venv.bak/
 # PyCharm projecy settings
 .idea
 
+# VSCode
+.vscode
+
 # mkdocs documentation
 /site
 

--- a/odoo_module_migrate/migration_scripts/migrate_120_130.py
+++ b/odoo_module_migrate/migration_scripts/migrate_120_130.py
@@ -1,6 +1,7 @@
 # Copyright (C) 2019 - Today: GRAP (http://www.grap.coop)
 # @author: Sylvain LE GAL (https://twitter.com/legalsylvain)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+import re
 
 _TEXT_ERRORS = {
     "*": {
@@ -32,5 +33,40 @@ _TEXT_REPLACES = {
     ".xml": {
         r"( |\t)*<field name=('|\")view_type('|\")>.*</field>\n": "",
         r"src_model": "binding_model",
-    }
+        re.compile(
+            r"""
+            # find a button...
+            <button
+                \s[^>]*
+                # ... that is a oe_stat_button
+                class=['"].*\b
+                    oe_stat_button
+                \b.*['"]
+                [^>]*>\s*
+                    # ... that contains a field
+                    <field\s+
+                        (
+                            [^>]*
+                            (
+                                # ...  named "active"
+                                name=['"]active['"]|
+                                # ... with a boolean_button widget
+                                widget=['"]boolean_button['"]
+                            )
+                            [^>]*
+                        ){2}
+                    [^>]*>\s*
+            </button>
+            """,
+            re.VERBOSE,
+        ): """
+            <field name="active" invisible="1" />
+            <widget
+                name="web_ribbon"
+                title="Archived"
+                bg_color="bg-danger"
+                attrs="{'invisible': [('active', '=', True)]}"
+            />
+            """,
+    },
 }

--- a/tests/data_result/module_080_130/views/sale_order.xml
+++ b/tests/data_result/module_080_130/views/sale_order.xml
@@ -34,4 +34,36 @@
             res_model="account.move.line"
             binding_model="account.move"
             view_mode="tree"/>
+
+        <record id="form_view" model="ir.ui.view">
+            <field name="name">Test Form</field>
+            <field name="model">account.move</field>
+            <field name="arch" type="xml">
+                <form>
+                    <sheet>
+                        <div class="oe_button_box" name="button_box">
+                            
+            <field name="active" invisible="1" />
+            <widget
+                name="web_ribbon"
+                title="Archived"
+                bg_color="bg-danger"
+                attrs="{'invisible': [('active', '=', True)]}"
+            />
+            
+                        </div>
+                        <div class="oe_title">
+                            <label for="name" class="oe_edit_only" />
+                            <h1>
+                                <field name="name" />
+                            </h1>
+                        </div>
+                    </sheet>
+                    <div class="oe_chatter">
+                        <field name="message_follower_ids" widget="mail_followers" />
+                        <field name="message_ids" widget="mail_thread" />
+                    </div>
+                </form>
+            </field>
+        </record>
 </odoo>

--- a/tests/data_template/module_080/views/sale_order.xml
+++ b/tests/data_template/module_080/views/sale_order.xml
@@ -39,5 +39,40 @@
             res_model="account.move.line"
             src_model="account.move"
             view_mode="tree"/>
+
+        <record id="form_view" model="ir.ui.view">
+            <field name="name">Test Form</field>
+            <field name="model">account.move</field>
+            <field name="arch" type="xml">
+                <form>
+                    <sheet>
+                        <div class="oe_button_box" name="button_box">
+                            <button
+                                class="oe_stat_button"
+                                icon="fa-archive"
+                                name="toggle_active"
+                                type="object"
+                            >
+                                <field
+                                    name="active"
+                                    options='{"terminology": "archive"}'
+                                    widget="boolean_button"
+                                />
+                            </button>
+                        </div>
+                        <div class="oe_title">
+                            <label for="name" class="oe_edit_only" />
+                            <h1>
+                                <field name="name" />
+                            </h1>
+                        </div>
+                    </sheet>
+                    <div class="oe_chatter">
+                        <field name="message_follower_ids" widget="mail_followers" />
+                        <field name="message_ids" widget="mail_thread" />
+                    </div>
+                </form>
+            </field>
+        </record>
     </data>
 </openerp>


### PR DESCRIPTION
Will translate this:

```xml
<div class="oe_button_box" name="button_box">
    <button
        class="oe_stat_button"
        icon="fa-archive"
        name="toggle_active"
        type="object"
    >
        <field
            name="active"
            options='{"terminology": "archive"}'
            widget="boolean_button"
        />
    </button>
</div>
```

Into this:

```xml

<div class="oe_button_box" name="button_box">
    <field name="active" invisible="1" />
    <widget
        name="web_ribbon"
        title="Archived"
        bg_color="bg-danger"
        attrs="{'invisible': [('active', '=', True)]}"
    />
</div>
```

Whitespace is bad formatted, but that's a job for #41.

@Tecnativa TT25940