### PR TITLE
[13.0] '.env.user.company_id' -> '.env.company' + Remove 'dp.get_precision' calls 

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include requirements.txt
+recursive-include odoo_module_migrate/migration_scripts/ *.py *.yaml

--- a/odoo_module_migrate/base_migration_script.py
+++ b/odoo_module_migrate/base_migration_script.py
@@ -33,22 +33,27 @@ class BaseMigrationScript(object):
             # {filetype: {regex: replacement}}
             "_TEXT_REPLACES": {
                 "type": TYPE_DICT_OF_DICT,
+                "doc": {},
             },
             # {filetype: {regex: message}}
             "_TEXT_ERRORS": {
                 "type": TYPE_DICT_OF_DICT,
+                "doc": {},
             },
             # {filetype: {regex: message}}
             "_TEXT_WARNINGS": {
                 "type": TYPE_DICT_OF_DICT,
+                "doc": {},
             },
             # [(module, why, ...)]
             "_DEPRECATED_MODULES": {
                 "type": TYPE_ARRAY,
+                "doc": [],
             },
             # {old_name: new_name}
             "_FILE_RENAMES": {
                 "type": TYPE_DICT,
+                "doc": {},
             },
         }
         # read
@@ -61,7 +66,16 @@ class BaseMigrationScript(object):
             )
             for filename in glob.glob(file_pattern):
                 with open(filename) as f:
-                    rules[rule]["doc"] = yaml.safe_load(f)
+                    new_rules = yaml.safe_load(f)
+                    if rules[rule]["type"] == TYPE_DICT_OF_DICT:
+                        for f_type, data in new_rules.items():
+                            if f_type not in rules[rule]["doc"]:
+                                rules[rule]["doc"][f_type] = {}
+                            rules[rule]["doc"][f_type].update(data)
+                    elif rules[rule]["type"] == TYPE_DICT:
+                        rules[rule]["doc"].update(new_rules)
+                    elif rules[rule]["type"] == TYPE_ARRAY:
+                        rules[rule]["doc"].extend(new_rules)
         # extend
         for rule, data in rules.items():
             rtype = data["type"]

--- a/odoo_module_migrate/migration_scripts/text_replaces/migrate_120_130/digits_precision.yaml
+++ b/odoo_module_migrate/migration_scripts/text_replaces/migrate_120_130/digits_precision.yaml
@@ -1,0 +1,4 @@
+.py:
+  import\sodoo\.addons\.decimal_precision\b.*\n:
+  from\sodoo\.addons\simport\sdecimal_precision\b.*\n:
+  digits\=dp\.get_precision\((?P<field>[^/)]+?)\): digits=\g<field>

--- a/odoo_module_migrate/migration_scripts/text_warnings/migrate_120_130/company.yaml
+++ b/odoo_module_migrate/migration_scripts/text_warnings/migrate_120_130/company.yaml
@@ -1,0 +1,3 @@
+
+.py:
+  env.user.company_id: "[13] If the intended use is to get the current active company, you need to change '.env.user.company_id' to '.env.company'"

--- a/setup.py
+++ b/setup.py
@@ -13,8 +13,9 @@ setuptools.setup(
     " to another",
     long_description=open('README.rst').read(),
     long_description_content_type='text/x-rst',
-    url="https://github.com/grap/odoo-module-migrator",
+    url="https://github.com/OCA/odoo-module-migrator",
     packages=['odoo_module_migrate', 'odoo_module_migrate.migration_scripts'],
+    include_package_data=True,
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Framework :: Odoo",

--- a/tests/data_result/module_120_130/__init__ .py
+++ b/tests/data_result/module_120_130/__init__ .py
@@ -1,0 +1,1 @@
+from . import models

--- a/tests/data_result/module_120_130/__manifest__.py
+++ b/tests/data_result/module_120_130/__manifest__.py
@@ -1,0 +1,8 @@
+# Copyright <YEAR(S)> <AUTHOR(S)>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+{
+    "name": "Module name",
+    "version": "13.0.1.0.0",
+    "installable": True,
+    "license": "AGPL-3",
+}

--- a/tests/data_result/module_120_130/models/product_multi_price.py
+++ b/tests/data_result/module_120_130/models/product_multi_price.py
@@ -1,0 +1,23 @@
+from odoo import fields, models, api
+
+
+class ProductMultiPrice(models.Model):
+    _name = 'product.multi.price'
+    _description = "Product Multiple Prices"
+
+    name = fields.Many2one(
+        comodel_name='product.multi.price.name',
+        required=True,
+        translate=True,
+    )
+    product_id = fields.Many2one(
+        comodel_name='product.product',
+        required=True,
+        ondelete='cascade',
+    )
+    price = fields.Float(
+        digits='Product Price',
+    )
+
+    def _some_method(self):
+        return self.env.user.company_id

--- a/tests/data_template/module_120/__init__.py
+++ b/tests/data_template/module_120/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/tests/data_template/module_120/__manifest__.py
+++ b/tests/data_template/module_120/__manifest__.py
@@ -1,0 +1,8 @@
+# Copyright <YEAR(S)> <AUTHOR(S)>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+{
+    "name": "Module name",
+    "version": "12.0.1.0.0",
+    "installable": False,
+    "license": "AGPL-3",
+}

--- a/tests/data_template/module_120/models/product_multi_price.py
+++ b/tests/data_template/module_120/models/product_multi_price.py
@@ -1,0 +1,27 @@
+from odoo import fields, models, api
+from odoo.addons import decimal_precision as dp
+import odoo.addons.decimal_precision
+
+
+class ProductMultiPrice(models.Model):
+    _name = 'product.multi.price'
+    _description = "Product Multiple Prices"
+
+    name = fields.Many2one(
+        comodel_name='product.multi.price.name',
+        required=True,
+        translate=True,
+    )
+    product_id = fields.Many2one(
+        comodel_name='product.product',
+        required=True,
+        ondelete='cascade',
+    )
+    price = fields.Float(
+        digits=dp.get_precision('Product Price'),
+    )
+
+    @api.one
+    @api.multi
+    def _some_method(self):
+        return self.env.user.company_id

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -74,6 +74,30 @@ class TestMigration(unittest.TestCase):
                 0,
                 "%s not found in the log" % pattern)
 
+    def test_migration_120_130(self):
+        self._migrate_module("module_120", "module_120_130", "12.0", "13.0")
+        comparison = self._get_comparison("module_120", "module_120_130")
+        diff_files = self._get_diff_files(comparison, "./")
+        log_content = _read_content(str(self._working_path / "test_log.log"))
+        self.assertEqual(
+            len(diff_files), 0,
+            "Differences found in the following files\n- %s" % (
+                "\n- ".join(diff_files)))
+
+        required_logs = [
+            (
+                "WARNING",
+                "[13].*change.*env\\.user\\.company_id.*to.*\\.env\\.company",
+            ),
+        ]
+        for required_log in required_logs:
+            level, message = required_log
+            pattern = "{0}.*{1}".format(level, message)
+            self.assertNotEqual(
+                len(re.findall(pattern, log_content)),
+                0,
+                "%s not found in the log" % pattern)
+
     def test_migration_130_140(self):
         self._migrate_module("module_130", "module_130_140", "13.0", "14.0")
         comparison = self._get_comparison("module_130", "module_130_140")


### PR DESCRIPTION
1.  Warn about change from `.env.user.company_id` to `.env.company`
2. Remove `dp.get_precision` calls

Example:
1. New warning:
```bash
jota@jlap:~/D/T/p/d/o/c/s/product-attribute|12.0✓
➤ odoo-module-migrate -m $MODULE --init-version-name 12.0 --target-version-name 13.0 --no-commit
07:28:23   INFO        [product_multi_price] Running migration from 12.0 to 13.0
07:28:23   INFO        Removing 'migrations' folder
07:28:23   INFO        Change file content of multi_price_views.xml
07:28:23   WARNING     [13] If the intended use is to get 'current active company', you need to change '.env.user.company_id' to '.env.company'. File [...]
07:28:23   INFO        Change file content of product_multi_price.py
07:28:23   WARNING     [13] If the intended use is to get 'current active company', you need to change '.env.user.company_id' to '.env.company'. File [...]
```
2. Remove call:
```diff
diff --git a/product_multi_price/models/product_multi_price.py b/product_multi_price/models/product_multi_price.py
index 8be0abf2..0235f92a 100644
--- a/product_multi_price/models/product_multi_price.py
+++ b/product_multi_price/models/product_multi_price.py
@@ -1,7 +1,6 @@
 # Copyright 2020 Tecnativa - David Vidal
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 from odoo import api, fields, models
-from odoo.addons import decimal_precision as dp
 
 
 class ProductMultiPrice(models.Model):
@@ -19,7 +18,7 @@ class ProductMultiPrice(models.Model):
         ondelete='cascade',
     )
     price = fields.Float(
-        digits=dp.get_precision('Product Price'),
+        digits='Product Price',
     )
     company_id = fields.Many2one(
         comodel_name='res.company',
```

@Tecnativa
TT27865