### PR TITLE
[IMP] make remove migration folder optional

### DIFF
--- a/odoo_module_migrate/__main__.py
+++ b/odoo_module_migrate/__main__.py
@@ -107,6 +107,13 @@ def get_parser():
         help="Skip pre-commit execution",
     )
 
+    # TODO: Move to `argparse.BooleanOptionalAction` once in Python 3.9+
+    main_parser.add_argument(
+        "-nrmf", "--no-remove-migration-folder",
+        dest="remove_migration_folder", action="store_false",
+        help="Skip removing migration folder",
+    )
+
     return main_parser
 
 
@@ -130,7 +137,7 @@ def main(args=False):
         migration = Migration(
             args.directory, args.init_version_name, args.target_version_name,
             module_names, args.format_patch, args.remote_name,
-            not args.no_commit, args.pre_commit,
+            not args.no_commit, args.pre_commit, args.remove_migration_folder,
         )
 
         # run Migration

--- a/odoo_module_migrate/migration.py
+++ b/odoo_module_migrate/migration.py
@@ -21,12 +21,13 @@ class Migration:
     def __init__(
         self, relative_directory_path, init_version_name, target_version_name,
         module_names=None, format_patch=False, remote_name='origin',
-        commit_enabled=True, pre_commit=True,
+        commit_enabled=True, pre_commit=True, remove_migration_folder=True,
     ):
         if not module_names:
             module_names = []
         self._commit_enabled = commit_enabled
         self._pre_commit = pre_commit
+        self._remove_migration_folder = remove_migration_folder
         self._migration_steps = []
         self._migration_scripts = []
         self._module_migrations = []
@@ -161,6 +162,13 @@ class Migration:
                 "odoo_module_migrate.migration_scripts.migrate_allways"
             )
         )
+        if self._remove_migration_folder:
+            self._migration_scripts.extend(
+                self._load_migration_script(
+                    "odoo_module_migrate.migration_scripts."
+                    "migrate_remove_migration_folder"
+                )
+            )
         all_packages = importlib.\
             import_module("odoo_module_migrate.migration_scripts")
 
@@ -171,7 +179,7 @@ class Migration:
                 all_packages.__path__):
             # Ignore script that will be allways executed.
             # this script will be added at the end.
-            if name == 'migrate_allways':
+            if name in ('migrate_allways', 'migrate_remove_migration_folder'):
                 continue
 
             # Filter migration scripts, depending of the configuration

--- a/odoo_module_migrate/migration_scripts/migrate_allways.py
+++ b/odoo_module_migrate/migration_scripts/migrate_allways.py
@@ -2,8 +2,6 @@
 # @author: Sylvain LE GAL (https://twitter.com/legalsylvain)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-import os
-import subprocess
 from odoo_module_migrate.base_migration_script import BaseMigrationScript
 
 _TEXT_REPLACES = {
@@ -22,20 +20,8 @@ def set_module_installable(**kwargs):
         manifest_path, {old_term: new_term}, "Set module installable")
 
 
-def remove_migration_folder(**kwargs):
-    logger = kwargs['logger']
-    module_path = kwargs['module_path']
-    migration_path_folder = os.path.join(module_path, 'migrations')
-    if os.path.exists(migration_path_folder):
-        logger.info("Removing 'migrations' folder")
-        subprocess.check_output(
-            "rm -r %s" % migration_path_folder, shell=True
-        )
-
-
 class MigrationScript(BaseMigrationScript):
     _TEXT_REPLACES = _TEXT_REPLACES
     _GLOBAL_FUNCTIONS = [
-        remove_migration_folder,
         set_module_installable,
     ]

--- a/odoo_module_migrate/migration_scripts/migrate_remove_migration_folder.py
+++ b/odoo_module_migrate/migration_scripts/migrate_remove_migration_folder.py
@@ -1,0 +1,24 @@
+# Copyright (C) 2019 - Today: GRAP (http://www.grap.coop)
+# @author: Sylvain LE GAL (https://twitter.com/legalsylvain)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+import os
+import subprocess
+from odoo_module_migrate.base_migration_script import BaseMigrationScript
+
+
+def remove_migration_folder(**kwargs):
+    logger = kwargs['logger']
+    module_path = kwargs['module_path']
+    migration_path_folder = os.path.join(module_path, 'migrations')
+    if os.path.exists(migration_path_folder):
+        logger.info("Removing 'migrations' folder")
+        subprocess.check_output(
+            "rm -r %s" % migration_path_folder, shell=True
+        )
+
+
+class MigrationScript(BaseMigrationScript):
+    _GLOBAL_FUNCTIONS = [
+        remove_migration_folder,
+    ]


### PR DESCRIPTION
Using odoo upgrade service and skiping versions, it's useful for previous migration scripts to remain there.

Maybe this is not ok for OCA repositories but can be used on custom repositories.