### PR TITLE
Initialize 15.0 to 16.0 scripts

### DIFF
--- a/odoo_module_migrate/migration_scripts/migrate_140_150.py
+++ b/odoo_module_migrate/migration_scripts/migrate_140_150.py
@@ -1,0 +1,7 @@
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo_module_migrate.base_migration_script import BaseMigrationScript
+
+
+class MigrationScript(BaseMigrationScript):
+    pass

--- a/odoo_module_migrate/migration_scripts/migrate_150_160.py
+++ b/odoo_module_migrate/migration_scripts/migrate_150_160.py
@@ -1,0 +1,7 @@
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo_module_migrate.base_migration_script import BaseMigrationScript
+
+
+class MigrationScript(BaseMigrationScript):
+    pass

--- a/odoo_module_migrate/migration_scripts/migrate_150_160.py
+++ b/odoo_module_migrate/migration_scripts/migrate_150_160.py
@@ -5,6 +5,7 @@ from odoo_module_migrate.base_migration_script import BaseMigrationScript
 _TEXT_REPLACES = {
     ".py": {
         r"\.get_xml_id\(": ".get_external_id(",
+        r"\.fields_get_keys\(\)": "._fields",
     },
 }
 

--- a/odoo_module_migrate/migration_scripts/migrate_150_160.py
+++ b/odoo_module_migrate/migration_scripts/migrate_150_160.py
@@ -2,6 +2,12 @@
 
 from odoo_module_migrate.base_migration_script import BaseMigrationScript
 
+_TEXT_REPLACES = {
+    ".py": {
+        r"\.get_xml_id\(": ".get_external_id(",
+    },
+}
+
 
 class MigrationScript(BaseMigrationScript):
-    pass
+    _TEXT_REPLACES = _TEXT_REPLACES

--- a/tests/data_result/module_150_160/__init__.py
+++ b/tests/data_result/module_150_160/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/tests/data_result/module_150_160/__manifest__.py
+++ b/tests/data_result/module_150_160/__manifest__.py
@@ -1,0 +1,13 @@
+# Copyright 2022 Camptocamp SA (https://www.camptocamp.com).
+# @author Iván Todorovich <ivan.todorovich@camptocamp.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+{
+    "name": "Module name",
+    "version": "16.0.1.0.0",
+    "installable": True,
+    'license': 'AGPL-3',
+    'depends': [
+        'base',
+    ],
+}

--- a/tests/data_result/module_150_160/models/__init__.py
+++ b/tests/data_result/module_150_160/models/__init__.py
@@ -1,0 +1,1 @@
+from . import res_partner

--- a/tests/data_result/module_150_160/models/res_partner.py
+++ b/tests/data_result/module_150_160/models/res_partner.py
@@ -1,0 +1,17 @@
+# Copyright 2022 Camptocamp SA (https://www.camptocamp.com).
+# @author Iván Todorovich <ivan.todorovich@camptocamp.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class ResPartner(models.Model):
+    _inherit = "res.partner"
+
+    def test_get_record_xml_id(self):
+        return self.get_external_id()[self.id]
+
+    def test_loop_through_fields(self):
+        group_fields = [f for f in self._fields if f.startswith("group_")]
+        for group_field in group_fields:
+            print(group_field)

--- a/tests/data_template/module_150/__init__.py
+++ b/tests/data_template/module_150/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/tests/data_template/module_150/__manifest__.py
+++ b/tests/data_template/module_150/__manifest__.py
@@ -1,0 +1,13 @@
+# Copyright 2022 Camptocamp SA (https://www.camptocamp.com).
+# @author Iván Todorovich <ivan.todorovich@camptocamp.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+{
+    "name": "Module name",
+    "version": "15.0.1.0.0",
+    "installable": False,
+    'license': 'AGPL-3',
+    'depends': [
+        'base',
+    ],
+}

--- a/tests/data_template/module_150/models/__init__.py
+++ b/tests/data_template/module_150/models/__init__.py
@@ -1,0 +1,1 @@
+from . import res_partner

--- a/tests/data_template/module_150/models/res_partner.py
+++ b/tests/data_template/module_150/models/res_partner.py
@@ -1,0 +1,17 @@
+# Copyright 2022 Camptocamp SA (https://www.camptocamp.com).
+# @author Iván Todorovich <ivan.todorovich@camptocamp.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class ResPartner(models.Model):
+    _inherit = "res.partner"
+
+    def test_get_record_xml_id(self):
+        return self.get_xml_id()[self.id]
+
+    def test_loop_through_fields(self):
+        group_fields = [f for f in self.fields_get_keys() if f.startswith("group_")]
+        for group_field in group_fields:
+            print(group_field)

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -106,3 +106,12 @@ class TestMigration(unittest.TestCase):
             len(diff_files), 0,
             "Differences found in the following files\n- %s" % (
                 "\n- ".join(diff_files)))
+
+    def test_migration_150_160(self):
+        self._migrate_module("module_150", "module_150_160", "15.0", "16.0")
+        comparison = self._get_comparison("module_150", "module_150_160")
+        diff_files = self._get_diff_files(comparison, "./")
+        self.assertEqual(
+            len(diff_files), 0,
+            "Differences found in the following files\n- %s" % (
+                "\n- ".join(diff_files)))


### PR DESCRIPTION
Includes the migration for these changes:
- https://github.com/odoo/odoo/commit/8f7fad760196b2ad071e1e070a11003d9f02049f
  - Quoting [Migration to version 16.0](https://github.com/OCA/maintainer-tools/wiki/Migration-to-version-16.0):
    > - If using fields_get_keys() method for getting fields definition, now use directly _fields variable or get_views() method.
    > - If using get_xml_id() method for getting an ID, now use the method get_external_id().