### PR TITLE
[FIX] Allow spaces in path to target modules directory

### DIFF
--- a/odoo_module_migrate/tools.py
+++ b/odoo_module_migrate/tools.py
@@ -27,7 +27,7 @@ def _get_latest_version_code():
 
 def _execute_shell(shell_command, path=False, raise_error=True):
     if path:
-        shell_command = "cd %s && %s" % (str(path.resolve()), shell_command)
+        shell_command = "cd '%s' && %s" % (str(path.resolve()), shell_command)
     logger.debug("Execute Shell:\n%s" % (shell_command))
     if raise_error:
         return subprocess.check_output(shell_command, shell=True)


### PR DESCRIPTION
If the target modules directory contains spaces, the shell command would fail before this patch with a "no such file or directory" error as it would choke on the first space. By wrapping the directory name in single quotes before executing the shell command this is avoided.