### PR TITLE
[ADD] Add warning for related fields with store=True

### DIFF
--- a/odoo_module_migrate/migration_scripts/text_warnings/migrate_170_180/related_fields.yaml
+++ b/odoo_module_migrate/migration_scripts/text_warnings/migrate_170_180/related_fields.yaml
@@ -1,0 +1,2 @@
+.py:
+  related=.*store=True: "[18] It is no longer necessary to set store=True on related fields to group, aggregate, or sort them. Remove store=True unless it is strictly required. More details: https://github.com/odoo/odoo/pull/127353"


### PR DESCRIPTION
This PR adds a warning for related fields with `store=True`, as it is no longer necessary to store related fields for grouping, aggregating, or sorting in Odoo 18. The warning encourages developers to remove `store=True` unless strictly required, optimizing performance and reducing disk space usage.

More details can be found in the related Odoo PR: https://github.com/odoo/odoo/pull/127353