### PR TITLE
[IMP] replace editable attribute on list view

### DIFF
--- a/odoo_module_migrate/migration_scripts/migrate_170_180.py
+++ b/odoo_module_migrate/migration_scripts/migrate_170_180.py
@@ -149,6 +149,26 @@ def replace_ustr(
             logger.error(f"Error processing file {file}: {str(e)}")
 
 
+def replace_editable_attribute(
+    logger, module_path, module_name, manifest_path, migration_steps, tools
+):
+    files_to_process = tools.get_files(module_path, (".xml", ".js", ".py"))
+    replaces = {
+        'editable="1"': 'editable="bottom"',
+        "editable='1'": 'editable="bottom"',
+        r'<attribute\s+name=["\']editable["\']>1</attribute>': '<attribute name="editable">bottom</attribute>',
+    }
+    for file in files_to_process:
+        try:
+            tools._replace_in_file(
+                file,
+                replaces,
+                log_message=f"""Replace editable="1" by "bottom" in file: {file}""",
+            )
+        except Exception as e:
+            logger.error(f"Error processing file {file}: {str(e)}")
+
+
 class MigrationScript(BaseMigrationScript):
     _GLOBAL_FUNCTIONS = [
         replace_unaccent_parameter,
@@ -156,4 +176,5 @@ class MigrationScript(BaseMigrationScript):
         replace_chatter_blocks,
         replace_user_has_groups,
         replace_ustr,
+        replace_editable_attribute,
     ]

--- a/tests/data_result/module_170_180/__manifest__.py
+++ b/tests/data_result/module_170_180/__manifest__.py
@@ -10,5 +10,6 @@
     ],
     'data': [
         'views/res_partner.xml',
+        'views/product_template_view.xml',
     ],
 }

--- a/tests/data_result/module_170_180/views/product_template_view.xml
+++ b/tests/data_result/module_170_180/views/product_template_view.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="view_product_template_list_custom" model="ir.ui.view">
+        <field name="name">product.template.list.custom</field>
+        <field name="model">product.template</field>
+        <field name="arch" type="xml">
+            <list editable="bottom">
+                <field name="name"/>
+                <field name="active"/>
+            </list>
+        </field>
+    </record>
+
+</odoo>

--- a/tests/data_result/module_170_180/views/res_partner.xml
+++ b/tests/data_result/module_170_180/views/res_partner.xml
@@ -9,6 +9,9 @@
                 <field name="test_field_1"/>
                 <field name="active" widget="boolean_toggle"/>
             </list>
+            <list position="attribute">
+                <attribute name="editable">bottom</attribute>
+            </list>
         </field>
     </record>
     

--- a/tests/data_template/module_170/__manifest__.py
+++ b/tests/data_template/module_170/__manifest__.py
@@ -10,5 +10,6 @@
     ],
     'data': [
         'views/res_partner.xml',
+        'views/product_template_view.xml',
     ],
 }

--- a/tests/data_template/module_170/views/product_template_view.xml
+++ b/tests/data_template/module_170/views/product_template_view.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="view_product_template_list_custom" model="ir.ui.view">
+        <field name="name">product.template.list.custom</field>
+        <field name="model">product.template</field>
+        <field name="arch" type="xml">
+            <list editable="1">
+                <field name="name"/>
+                <field name="active"/>
+            </list>
+        </field>
+    </record>
+
+</odoo>

--- a/tests/data_template/module_170/views/res_partner.xml
+++ b/tests/data_template/module_170/views/res_partner.xml
@@ -9,6 +9,9 @@
                 <field name="test_field_1"/>
                 <field name="active" widget='toggle_button'/>
             </tree>
+            <tree position="attribute">
+                <attribute name="editable">1</attribute>
+            </tree>
         </field>
     </record>
     


### PR DESCRIPTION
replace `"1"` by `"bottom"` in editable attribute on list view.
base on: `https://github.com/odoo/odoo/pull/162937`

an example when migrating `account_corporate_budget_base`
```
(env) chien@nmc:~/code/odoo-module-migrator$ python -m odoo_module_migrate -d /home/chien/code/oca/smartcamp_core_private/17.0 -m account_corporate_budget_base -i 17.0 -t 18.0
12:27:39   INFO        Run pre-commit
An error has occurred: InvalidConfigError: 
=====> .pre-commit-config.yaml is not a file
Check the log at /home/chien/.cache/pre-commit/pre-commit.log
12:27:39   INFO        Stage and commit changes done by pre-commit
[pr_son_5 406f009] [IMP] account_corporate_budget_base: pre-commit execution
12:27:39   INFO        [account_corporate_budget_base] Running migration from 17.0 to 18.0
12:27:39   INFO        Bump version to 18.0.1.0.0
12:27:40   ERROR       Error processing file /home/chien/code/oca/smartcamp_core_private/17.0/account_corporate_budget_base/security: [Errno 21] Is a directory: '/home/chien/code/oca/smartcamp_core_private/17.0/account_corporate_budget_base/security'
12:27:40   INFO        Replace editable="1" by "bottom" in file: /home/chien/code/oca/smartcamp_core_private/17.0/account_corporate_budget_base/views/account_move_corporate_budget_line_views.xml
12:27:40   INFO        Commit changes for account_corporate_budget_base. commit name '[MIG] account_corporate_budget_base: Migration to 18.0'
```