### PR TITLE
[IMP] Warning for _invalidate_cache()

### DIFF
--- a/odoo_module_migrate/migration_scripts/text_warnings/migrate_160_allways/orm_methods.yaml
+++ b/odoo_module_migrate/migration_scripts/text_warnings/migrate_160_allways/orm_methods.yaml
@@ -1,0 +1,2 @@
+.py:
+  (_invalidate_cache\(.*\)): "[16+] Please avoid using the private method _invalidate_cache(). Instead, use the appropriate public method such as invalidate_model(), invalidate_recordset(), or env.invalidate_all() to ensure better maintainability, compatibility, and adherence to Odoo's API standards."


### PR DESCRIPTION
During migration, some developers might have naively replaced `invalidate_cache()` with `_invalidate_cache()`

=> We need to handle this specific case to avoid issues caused by changes in logic or the removal of private methods in the codebase