### PR TITLE
[ADD] Add warnings for new URL joining functions

### DIFF
--- a/odoo_module_migrate/migration_scripts/text_warnings/migrate_180_190/url_joining_functions.yaml
+++ b/odoo_module_migrate/migration_scripts/text_warnings/migrate_180_190/url_joining_functions.yaml
@@ -1,0 +1,2 @@
+.py:
+  url_?join\(: "[19] Review usage of URL joining functions (url_join, urljoin). Use 'tools.urls.urljoin' for safer URL joining. More information: https://github.com/odoo/odoo/commit/977e62d91f3e"


### PR DESCRIPTION
This PR adds migration warnings for the transition from Odoo 18.0 to 19.0 to help developers identify and update deprecated URL joining functions.

In Odoo 19.0, a new safer URL joining function was introduced in `odoo.tools.urls.urljoin()` to replace potentially unsafe URL joining methods from external libraries.

More information in **Related Odoo commit:** https://github.com/odoo/odoo/commit/977e62d91f3e

