### PR TITLE
[ADD] Add warning for deprecate _notify_progress in favor to _commit_progress

### DIFF
--- a/odoo_module_migrate/migration_scripts/text_warnings/migrate_180_190/cron_progress.yaml
+++ b/odoo_module_migrate/migration_scripts/text_warnings/migrate_180_190/cron_progress.yaml
@@ -1,0 +1,2 @@
+.py:
+  _notify_progress\(: "[19] _notify_progress is deprecated. Use _commit_progress instead. IMPORTANT: _commit_progress automatically commits the transaction, so remove any subsequent self.env.cr.commit() calls. Review documentation and examples: https://github.com/odoo/odoo/pull/207082/commits"


### PR DESCRIPTION
Add warning for deprecated _notify_progress method in favor to _commit_progress since requires manual intervention.
More information: https://github.com/odoo/odoo/pull/207082/commits