### PR TITLE
[ADD] Implement migration scripts and tests for renaming 'groups_id' to 'group_ids'

### DIFF
--- a/odoo_module_migrate/migration_scripts/text_replaces/migrate_180_190/rename_groups_id.yaml
+++ b/odoo_module_migrate/migration_scripts/text_replaces/migrate_180_190/rename_groups_id.yaml
@@ -1,0 +1,4 @@
+.xml:
+  (?<=name=[\"'])groups_id(?=[\"']): group_ids
+.py:
+  (?<=[\.\"'])groups_id(?=[\.\s,:)\]'\"]): group_ids

--- a/tests/data_result/module_180_190/models/res_partner.py
+++ b/tests/data_result/module_180_190/models/res_partner.py
@@ -1,4 +1,4 @@
-from odoo import models, fields
+from odoo import models, fields, api
 
 
 class ResPartner(models.Model):
@@ -20,3 +20,19 @@ class ResPartner(models.Model):
         'CHECK(LENGTH(test_field_2) > 2 AND LENGTH(test_field_2) < 100 AND test_field_2 IS NOT NULL)',
         "Name validation",
     )
+    
+    @api.model
+    def test_groups_id_usage(self):
+        # Test case 1: groups_id in domain
+        records = self.search([("group_ids", "in", [1, 2, 3])])
+        
+        # Test case 2: groups_id in field access
+        for record in records:
+            if record.group_ids:
+                print(record.group_ids.name)
+                
+        # Test case 3: groups_id in dictionary
+        vals = {"group_ids": [(6, 0, [1, 2])]}
+        self.create(vals)
+
+        return records

--- a/tests/data_result/module_180_190/views/res_partner.xml
+++ b/tests/data_result/module_180_190/views/res_partner.xml
@@ -6,6 +6,7 @@
         <field name="arch" type="xml">
             <field name="parent_id" position="after">
                 <field name="test_field_1"/>
+                <field name="group_ids"/>
             </field>
         </field>
     </record>

--- a/tests/data_template/module_180/models/res_partner.py
+++ b/tests/data_template/module_180/models/res_partner.py
@@ -1,4 +1,4 @@
-from odoo import models, fields
+from odoo import models, fields, api
 
 
 class ResPartner(models.Model):
@@ -13,3 +13,19 @@ class ResPartner(models.Model):
         ("phone_not_empty", "CHECK(test_field_2 IS NOT NULL OR test_field_2 IS NOT NULL)"),
         ("long_constraint_example", "CHECK(LENGTH(test_field_2) > 2 AND LENGTH(test_field_2) < 100 AND test_field_2 IS NOT NULL)", "Name validation"),
     ]
+    
+    @api.model
+    def test_groups_id_usage(self):
+        # Test case 1: groups_id in domain
+        records = self.search([("groups_id", "in", [1, 2, 3])])
+        
+        # Test case 2: groups_id in field access
+        for record in records:
+            if record.groups_id:
+                print(record.groups_id.name)
+                
+        # Test case 3: groups_id in dictionary
+        vals = {"groups_id": [(6, 0, [1, 2])]}
+        self.create(vals)
+
+        return records

--- a/tests/data_template/module_180/views/res_partner.xml
+++ b/tests/data_template/module_180/views/res_partner.xml
@@ -6,6 +6,7 @@
         <field name="arch" type="xml">
             <field name="parent_id" position="after">
                 <field name="test_field_1"/>
+                <field name="groups_id"/>
             </field>
         </field>
     </record>


### PR DESCRIPTION
The field `groups_id` was renamed to `group_ids` on models `res.users`, `ir.ui.view`, `ir.ui.menu`, `ir.actions`, `ir.actions.report` and `website.page.properties`. There are no other fields in Odoo still using the old `groups_id` name.
This commit updates all occurrences in both Python and XML files.

✔ Cases considered in Python:
  - `.groups_id.`
  - `.groups_id `(with space)
  - `.groups_id:`
  - `.groups_id,`
  - `.groups_id)`
  - `.groups_id]`
  - `'groups_id'`
  - `"groups_id"`

✔ Cases considered in XML:
  - `name="groups_id"`
  - `name='groups_id'`
  
  For more details: [odoo/odoo#179354](https://github.com/odoo/odoo/pull/179354)