### PR TITLE
[ADD] Add timezone migration warnings for v18→v19

### DIFF
--- a/odoo_module_migrate/migration_scripts/text_warnings/migrate_180_190/timezone.yaml
+++ b/odoo_module_migrate/migration_scripts/text_warnings/migrate_180_190/timezone.yaml
@@ -1,0 +1,7 @@
+.py:
+  pytz\.timezone\(\s*self\.env\.(context\.get\(\s*['"']tz['"']|user\.tz):
+    "[19] Replace manual timezone handling with 'self.env.tz'. This new property provides automatic timezone resolution with proper fallbacks (context -> user -> UTC). More info: https://github.com/odoo/odoo/pull/221541"
+  timezone\(\s*self\.env\.(context\.get\(\s*['"']tz['"']|user\.tz):
+    "[19] Replace manual timezone handling with 'self.env.tz'. This new property provides automatic timezone resolution with proper fallbacks (context -> user -> UTC). More info: https://github.com/odoo/odoo/pull/221541"
+  (\w+)\.env\.context\.get\(\s*['"']tz['"']:
+    "[19] Replace manual timezone context access with 'env.tz'. This new property provides automatic timezone resolution with proper fallbacks (context -> user -> UTC). More info: https://github.com/odoo/odoo/pull/221541"


### PR DESCRIPTION
Adds warnings for deprecated timezone patterns that can optionally be updated to use the new env.tz property introduced in Odoo 19.

Changes:

New timezone.yaml detecting manual timezone handling patterns
Warns about pytz.timezone(self.env.context.get('tz')...) and similar usage 
References: https://github.com/odoo/odoo/pull/221541 

Detected patterns:

pytz.timezone(self.env.context.get('tz') or self.env.user.tz)
timezone(self.env.context.get('tz')...)
*.env.context.get('tz') access patterns

The new self.env.tz property provides automatic fallback handling (context → user → UTC) 