### PR TITLE
migrate_180_190 - upgrade_sql_constraints - ignore syntax error when the constraint is commented

### DIFF
--- a/tests/data_result/module_180_190/models/res_partner.py
+++ b/tests/data_result/module_180_190/models/res_partner.py
@@ -21,17 +21,17 @@ class ResPartner(models.Model):
         'CHECK(LENGTH(test_field_2) > 2 AND LENGTH(test_field_2) < 100 AND test_field_2 IS NOT NULL)',
         "Name validation",
     )
-    
+
     @api.model
     def test_groups_id_usage(self):
         # Test case 1: groups_id in domain
         records = self.search([("group_ids", "in", [1, 2, 3])])
-        
+
         # Test case 2: groups_id in field access
         for record in records:
             if record.group_ids:
                 print(record.group_ids.name)
-                
+
         # Test case 3: groups_id in dictionary
         vals = {"group_ids": [(6, 0, [1, 2])]}
         self.create(vals)
@@ -41,5 +41,5 @@ class ResPartner(models.Model):
     def search_with_expression(self, domain):
         result = Domain.AND([domain, [('active', '=', True)]])
         result2 = Domain.AND([result, Domain.OR([[('is_company', '=', True)]])])
-        
+
         return self.search(result2)

--- a/tests/data_result/module_180_190/models/sale_order.py
+++ b/tests/data_result/module_180_190/models/sale_order.py
@@ -4,7 +4,11 @@ from odoo.fields import Domain
 
 class SaleOrder(models.Model):
     _inherit = "sale.order"
-    
+
+    # _sql_constraints = [
+    #     ("name_uniq", "unique(name)", "The sale order name must be unique!")
+    # ]
+
     def simple_search(self, base_domain):
         extra_domain = [('state', '=', 'sale')]
         result1 = Domain.AND([base_domain, extra_domain])

--- a/tests/data_template/module_180/models/res_partner.py
+++ b/tests/data_template/module_180/models/res_partner.py
@@ -15,17 +15,17 @@ class ResPartner(models.Model):
         ("phone_not_empty", "CHECK(test_field_2 IS NOT NULL OR test_field_2 IS NOT NULL)"),
         ("long_constraint_example", "CHECK(LENGTH(test_field_2) > 2 AND LENGTH(test_field_2) < 100 AND test_field_2 IS NOT NULL)", "Name validation"),
     ]
-    
+
     @api.model
     def test_groups_id_usage(self):
         # Test case 1: groups_id in domain
         records = self.search([("groups_id", "in", [1, 2, 3])])
-        
+
         # Test case 2: groups_id in field access
         for record in records:
             if record.groups_id:
                 print(record.groups_id.name)
-                
+
         # Test case 3: groups_id in dictionary
         vals = {"groups_id": [(6, 0, [1, 2])]}
         self.create(vals)
@@ -35,5 +35,5 @@ class ResPartner(models.Model):
     def search_with_expression(self, domain):
         result = expression.AND([domain, [('active', '=', True)]])
         result2 = AND([result, OR([[('is_company', '=', True)]])])
-        
+
         return self.search(result2)

--- a/tests/data_template/module_180/models/sale_order.py
+++ b/tests/data_template/module_180/models/sale_order.py
@@ -4,7 +4,11 @@ from odoo.osv import expression
 
 class SaleOrder(models.Model):
     _inherit = "sale.order"
-    
+
+    # _sql_constraints = [
+    #     ("name_uniq", "unique(name)", "The sale order name must be unique!")
+    # ]
+
     def simple_search(self, base_domain):
         extra_domain = [('state', '=', 'sale')]
         result1 = expression.AND([base_domain, extra_domain])


### PR DESCRIPTION

Error:

```
  File ".../odoo-module-migrator/odoo_module_migrate/migration_scripts/migrate_180_190.py", line 80, in build_sql_object
    constraints = ast.literal_eval("[" + match.group(1) + "]")
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".../lib/python3.12/ast.py", line 66, in literal_eval
    node_or_string = parse(node_or_string.lstrip(" \t"), mode='eval')
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".../lib/python3.12/ast.py", line 52, in parse
    return compile(source, filename, mode, flags,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<unknown>", line 1
    [
    ^
SyntaxError: '[' was never closed
```