### PR TITLE
[IMP] act_window conversion: don't replace plain string using re.sub

### DIFF
--- a/odoo_module_migrate/migration_scripts/migrate_130_140.py
+++ b/odoo_module_migrate/migration_scripts/migrate_130_140.py
@@ -105,7 +105,7 @@ def _reformat_file(file_path: Path):
             et.indent(tag, space=indent, level=1)
             # Remove trailing newline
             tag_string = et.tostring(tag, pretty_print=True)[:-1]
-            xml_file = re.sub(tag_match, tag_string.decode(), xml_file)
+            xml_file = xml_file.replace(tag_match, tag_string.decode())
 
     # Write the file out again
     file_path.write_text(xml_file)

--- a/tests/data_result/module_130_140/views/sale_order.xml
+++ b/tests/data_result/module_130_140/views/sale_order.xml
@@ -4,6 +4,7 @@
         <field name="name">Example</field>
         <field name="res_model">account.move.line</field>
         <field name="binding_model_id" ref="account.model_account_move"/>
+        <field name="domain">[('id', '&gt;', 0)]</field>
         <field name="view_mode">tree</field>
     </record>
     <record id="report_example" model="ir.actions.report">

--- a/tests/data_template/module_130/views/sale_order.xml
+++ b/tests/data_template/module_130/views/sale_order.xml
@@ -5,6 +5,7 @@
         name="Example"
         res_model="account.move.line"
         src_model="account.move"
+        domain="[('id', '&gt;', 0)]"
         view_mode="tree"/>
     <report
         id="report_example"


### PR DESCRIPTION
converting act_window tags will fail when the tag contains a domain, because `re.sub` expects a regex, while we want to replace just the string